### PR TITLE
[feat & design] : 로그인 서버 연결 작동 확인 및 디자인 틀대로 구현 ( 추후 디자인 확정되면 수정할 것 )

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,4 +1,0 @@
-VITE_GOOGLE_CLIENT_ID=1058104025306-q2gsmc54sk2tu0upuinhakeistb3tfnu.apps.googleusercontent.com
-VITE_GOOGLE_CALLBACK_URL=http://localhost:5173
-VITE_BACKEND_API_URL=
-VITE_KAKAO_APP_KEY=0aa6be5d0232e4222f839baa7f4890b6

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,7 +20,8 @@
         "react-naver-login": "^0.1.4",
         "react-redux": "^9.2.0",
         "react-router-dom": "^7.3.0",
-        "redux": "^5.0.1"
+        "redux": "^5.0.1",
+        "tailwind-scrollbar-hide": "^2.0.0"
       },
       "devDependencies": {
         "@commitlint/cli": "^19.7.1",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,9 +19,8 @@
         "react-kakao-login": "^2.1.1",
         "react-naver-login": "^0.1.4",
         "react-redux": "^9.2.0",
-        "react-router-dom": "^7.2.0",
-        "redux": "^5.0.1",
-        "tailwind-scrollbar-hide": "^2.0.0"
+        "react-router-dom": "^7.3.0",
+        "redux": "^5.0.1"
       },
       "devDependencies": {
         "@commitlint/cli": "^19.7.1",
@@ -6908,9 +6907,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.2.0.tgz",
-      "integrity": "sha512-fXyqzPgCPZbqhrk7k3hPcCpYIlQ2ugIXDboHUzhJISFVy2DEPsmHgN588MyGmkIOv3jDgNfUE3kJi83L28s/LQ==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.3.0.tgz",
+      "integrity": "sha512-466f2W7HIWaNXTKM5nHTqNxLrHTyXybm7R0eBlVSt0k/u55tTCDO194OIx/NrYD4TS5SXKTNekXfT37kMKUjgw==",
       "license": "MIT",
       "dependencies": {
         "@types/cookie": "^0.6.0",
@@ -6932,12 +6931,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.2.0.tgz",
-      "integrity": "sha512-cU7lTxETGtQRQbafJubvZKHEn5izNABxZhBY0Jlzdv0gqQhCPQt2J8aN5ZPjS6mQOXn5NnirWNh+FpE8TTYN0Q==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.3.0.tgz",
+      "integrity": "sha512-z7Q5FTiHGgQfEurX/FBinkOXhWREJIAB2RiU24lvcBa82PxUpwqvs/PAXb9lJyPjTs2jrl6UkLvCZVGJPeNuuQ==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.2.0"
+        "react-router": "7.3.0"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,8 @@
     "react-naver-login": "^0.1.4",
     "react-redux": "^9.2.0",
     "react-router-dom": "^7.3.0",
-    "redux": "^5.0.1"
+    "redux": "^5.0.1",
+    "tailwind-scrollbar-hide": "^2.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.7.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,9 +22,8 @@
     "react-kakao-login": "^2.1.1",
     "react-naver-login": "^0.1.4",
     "react-redux": "^9.2.0",
-    "react-router-dom": "^7.2.0",
-    "redux": "^5.0.1",
-    "tailwind-scrollbar-hide": "^2.0.0"
+    "react-router-dom": "^7.3.0",
+    "redux": "^5.0.1"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.7.1",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -21,6 +21,8 @@ function App() {
           <Route path="/signup" element={<SignUpPage />} />
           
         </Routes>
+        
+        <GoogleLoginComponent />
       </Router>
     </GoogleOAuthProvider>
   )

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,9 +1,15 @@
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import LoginPage from '~/pages/login-page.jsx';
 import { GoogleOAuthProvider } from "@react-oauth/google";
+<<<<<<< HEAD
 import SignUpPage from "~/pages/signup-page.jsx";
 import Layout from "~/components/layout";
 import Streaming from "~/pages/streaming";
+=======
+import Main from "~/main-page.jsx";
+// import GoogleLoginComponent from "~/components/social-login/google-login";
+
+>>>>>>> 094f654 (로그인 구글 버튼 UI 통일 & src/ @->~로 변경)
 function App() {
 
   return (
@@ -11,7 +17,7 @@ function App() {
       GoogleOAuthProvider는 Google 로그인 기능을 전역에서 사용할 수 있도록 설정하는 컨텍스트
       이걸 감싸야 GoogleLogin과 useOneTap이 정상적으로 작동함
     */
-    <GoogleOAuthProvider clientId={import.meta.env.VITE_GOOGLE_CLIENT_ID}>
+    <GoogleOAuthProvider>
       <Router>
         <Routes>
           <Route path="/" element={<Layout />}>
@@ -21,8 +27,6 @@ function App() {
           <Route path="/signup" element={<SignUpPage />} />
           
         </Routes>
-        
-        <GoogleLoginComponent />
       </Router>
     </GoogleOAuthProvider>
   )

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,15 +1,10 @@
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import LoginPage from '~/pages/login-page.jsx';
 import { GoogleOAuthProvider } from "@react-oauth/google";
-<<<<<<< HEAD
 import SignUpPage from "~/pages/signup-page.jsx";
 import Layout from "~/components/layout";
 import Streaming from "~/pages/streaming";
-=======
-import Main from "~/main-page.jsx";
-// import GoogleLoginComponent from "~/components/social-login/google-login";
 
->>>>>>> 094f654 (로그인 구글 버튼 UI 통일 & src/ @->~로 변경)
 function App() {
 
   return (

--- a/frontend/src/components/social-login/google-login.jsx
+++ b/frontend/src/components/social-login/google-login.jsx
@@ -57,7 +57,7 @@ const GoogleLoginComponent = () => {
 
   return (
     <button onClick={onGoogleLogin} className="btn btn-google flex items-center 
-      justify-start gap-10 bg-blue-700 text-black py-2 px-4 rounded-full
+      justify-start gap-8 bg-blue-700 text-black py-2 px-6 rounded-full
       hover:bg-blue-600 transition-colors duration-200">
       <img
         src="/images/google-logo.png"

--- a/frontend/src/components/social-login/google-login.jsx
+++ b/frontend/src/components/social-login/google-login.jsx
@@ -58,7 +58,8 @@ const GoogleLoginComponent = () => {
   return (
     <button onClick={onGoogleLogin} className="btn btn-google flex items-center 
       justify-start gap-8 bg-blue-700 text-black py-2 px-6 rounded-full
-      hover:bg-blue-600 transition-colors duration-200">
+      hover:bg-blue-600 transition-colors duration-200 
+      hover:scale-105 transition-all duration-200 ">
       <img
         src="/images/google-logo.png"
         alt="구글 로고"

--- a/frontend/src/components/social-login/google-login.jsx
+++ b/frontend/src/components/social-login/google-login.jsx
@@ -1,67 +1,72 @@
 import { useDispatch } from "react-redux";
 import { loginSuccess } from "~/redux/auth-slice";
 import { useEffect } from "react";
+import "~/index.css";
 import { useNavigate } from "react-router-dom";
 
 const GoogleLoginComponent = () => {
   const dispatch = useDispatch(); // Redux 디스패치 훅
   const navigate = useNavigate(); // React Router 훅 (리디렉션 용)
 
-  const handleGoogleLoginSuccess = async (response) => {
-    try {
-      // 구글 로그인 후 받은 토큰을 백엔드로 전송
-      const res = await fetch("http://localhost:8080/api/v1/auth/google", {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ token: response.credential }),
-      });
-  
-      if (!res.ok) throw new Error('Failed to fetch'); // 응답 실패 시 에러 처리
-      const data = await res.json(); // 백엔드에서 받은 데이터
+  useEffect(() => {
+    const exchangeToken = async () => {
+      try {
+        const response = await fetch(
+          "http://localhost:8080/api/v1/auth/token-exchange", // 백엔드의 토큰 교환 API
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            credentials: "include", // 쿠키 포함
+          }
+        );
 
-      // Redux 스토어에 사용자 정보와 토큰을 저장
-      dispatch(loginSuccess({ user: data.user, token: data.token }));
-
-      // 신규 사용자면 회원가입 페이지로, 기존 사용자면 메인 페이지로 리디렉션
-      if (data.isNewUser) {
-        navigate('/signup');
-      } else {
-        navigate('/main');
+        if (response.ok) {
+          const accessToken = response.headers.get("Authorization");
+          if (accessToken) {
+            localStorage.setItem("access-token", accessToken);
+            dispatch(loginSuccess({ accessToken }));
+            navigate("/main"); // 메인 페이지로 이동
+          }
+        } else {
+          console.error("Token exchange failed");
+        }
+      } catch (error) {
+        console.error("Error during token exchange:", error);
       }
+    };
 
-      console.log('Login Success:', data);
-    } catch (error) {
-      console.error('Google Login Failed:', error);
+    // 에러 발생 시 회원가입 페이지 유지
+    const params = new URLSearchParams(window.location.search);
+    const error = params.get("error");
+
+    if (error) {
+      alert("이메일이 중복되었습니다. 다른 계정으로 회원가입해주세요.");
+      navigate("/signup");
+    } else {
+      exchangeToken(); // 로그인 성공 시 토큰 교환
     }
+  }, [navigate, dispatch]);
+
+  // OAuth 회원가입 버튼 클릭 시 해당 소셜 로그인 URL로 이동
+  const onGoogleLogin = (provider) => {
+    const redirectUri = "http://localhost:5173/main"; // 로그인 후 리디렉션할 URI
+    window.location.href = `http://localhost:8080/oauth2/authorization/${provider}?redirect_uri=${encodeURIComponent(redirectUri)}`;
   };
 
-  useEffect(() => {
-    // 구글 로그인 SDK 로드
-    const script = document.createElement("script");
-    script.src = "https://accounts.google.com/gsi/client";
-    script.async = true;
-    script.onload = () => {
-      // 구글 로그인 초기화
-      window.google.accounts.id.initialize({
-        // 환경 변수에서 구글 클라이언트 ID 가져오기
-        client_id: import.meta.env.VITE_GOOGLE_CLIENT_ID,
-        callback: handleGoogleLoginSuccess, // 로그인 성공 후 호출될 함수
-      });
-
-      // 로그인 버튼을 렌더링
-      window.google.accounts.id.renderButton(
-        document.getElementById("google-login-button"),
-        {
-          theme: "outline", // 버튼 스타일 (outline, light, dark 등)
-          size: "large",    // 버튼 크기 (small, medium, large 등)
-          shape: "pill",    // 버튼 모양 (rectangular, pill, circle 등)
-        }
-      );
-    };
-    document.head.appendChild(script); // 스크립트 태그 문서에 추가
-  }, []); // 페이지 로드 시 한 번만 실행
-
-  return <div id="google-login-button" className="flex justify-center"></div>;
+  return (
+    <button onClick={onGoogleLogin} className="btn btn-google flex items-center 
+      justify-start gap-10 bg-blue-700 text-black py-2 px-4 rounded-full
+      hover:bg-blue-600 transition-colors duration-200">
+      <img
+        src="/images/google-logo.png"
+        alt="구글 로고"
+        className="w-8 h-8"
+      />
+      <span className="ml-20">구글로 로그인</span>
+    </button>
+  );
 };
 
 export default GoogleLoginComponent;

--- a/frontend/src/components/social-login/google-login.jsx
+++ b/frontend/src/components/social-login/google-login.jsx
@@ -1,44 +1,65 @@
 import { useDispatch } from "react-redux";
 import { loginSuccess } from "~/redux/auth-slice";
 import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 
 const GoogleLoginComponent = () => {
-  const dispatch = useDispatch();
+  const dispatch = useDispatch(); // Redux 디스패치 훅
+  const navigate = useNavigate(); // React Router 훅 (리디렉션 용)
 
   const handleGoogleLoginSuccess = async (response) => {
     try {
-      const res = await fetch('http://localhost:8080/api/v1/auth/token-exchange', {
+      // 구글 로그인 후 받은 토큰을 백엔드로 전송
+      const res = await fetch("http://localhost:8080/api/v1/auth/google", {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ token: response.credential }),
       });
   
-      if (!res.ok) throw new Error('Failed to fetch');
-      const data = await res.json();
+      if (!res.ok) throw new Error('Failed to fetch'); // 응답 실패 시 에러 처리
+      const data = await res.json(); // 백엔드에서 받은 데이터
+
+      // Redux 스토어에 사용자 정보와 토큰을 저장
       dispatch(loginSuccess({ user: data.user, token: data.token }));
+
+      // 신규 사용자면 회원가입 페이지로, 기존 사용자면 메인 페이지로 리디렉션
+      if (data.isNewUser) {
+        navigate('/signup');
+      } else {
+        navigate('/main');
+      }
+
+      console.log('Login Success:', data);
     } catch (error) {
       console.error('Google Login Failed:', error);
     }
   };
 
   useEffect(() => {
-    // 구글 로그인 SDK를 로드합니다.
+    // 구글 로그인 SDK 로드
     const script = document.createElement("script");
     script.src = "https://accounts.google.com/gsi/client";
     script.async = true;
     script.onload = () => {
+      // 구글 로그인 초기화
       window.google.accounts.id.initialize({
+        // 환경 변수에서 구글 클라이언트 ID 가져오기
         client_id: import.meta.env.VITE_GOOGLE_CLIENT_ID,
-        callback: handleGoogleLoginSuccess,
+        callback: handleGoogleLoginSuccess, // 로그인 성공 후 호출될 함수
       });
 
+      // 로그인 버튼을 렌더링
       window.google.accounts.id.renderButton(
         document.getElementById("google-login-button"),
-        { theme: "outline", size: "large", shape: "pill" }
+        {
+          theme: "outline", // 버튼 스타일 (outline, light, dark 등)
+          size: "large",    // 버튼 크기 (small, medium, large 등)
+          shape: "pill",    // 버튼 모양 (rectangular, pill, circle 등)
+        }
       );
     };
-    document.head.appendChild(script);
-  }, []);
+    document.head.appendChild(script); // 스크립트 태그 문서에 추가
+  }, []); // 페이지 로드 시 한 번만 실행
 
   return <div id="google-login-button" className="flex justify-center"></div>;
 };

--- a/frontend/src/components/social-login/google-login.jsx
+++ b/frontend/src/components/social-login/google-login.jsx
@@ -50,9 +50,8 @@ const GoogleLoginComponent = () => {
   }, [navigate, dispatch]);
 
   // OAuth 회원가입 버튼 클릭 시 해당 소셜 로그인 URL로 이동
-  const onGoogleLogin = (provider) => {
-    const redirectUri = "http://localhost:5173/main"; // 로그인 후 리디렉션할 URI
-    window.location.href = `http://localhost:8080/oauth2/authorization/${provider}?redirect_uri=${encodeURIComponent(redirectUri)}`;
+  const onGoogleLogin = () => {
+    window.location.href = "http://localhost:8080/oauth2/authorization/google";
   };
 
   return (

--- a/frontend/src/components/social-login/google-login.jsx
+++ b/frontend/src/components/social-login/google-login.jsx
@@ -55,16 +55,17 @@ const GoogleLoginComponent = () => {
   };
 
   return (
-    <button onClick={onGoogleLogin} className="btn btn-google flex items-center 
-      justify-start gap-8 bg-blue-700 text-black py-2 px-6 rounded-full
-      hover:bg-blue-600 transition-colors duration-200 
-      hover:scale-105 transition-all duration-200 ">
-      <img
-        src="/images/google-logo.png"
-        alt="구글 로고"
-        className="w-8 h-8"
+    <button onClick={onGoogleLogin} className="btn btn-google bg-blue-400 text-black 
+       rounded-full hover:bg-blue-500 transition-colors duration-200 
+       hover:scale-105 transition-all duration-200"
+    >
+      <img 
+        src="/images/google-logo.png" 
+        alt="구글 로고" className="w-8 h-8 absolute left-5" 
       />
-      <span className="ml-20">구글로 로그인</span>
+      <span className="flex-1 text-center text-black">
+        구글로 로그인
+      </span>
     </button>
   );
 };

--- a/frontend/src/components/social-login/google-login.jsx
+++ b/frontend/src/components/social-login/google-login.jsx
@@ -2,11 +2,11 @@ import { useDispatch } from "react-redux";
 import { loginSuccess } from "~/redux/auth-slice";
 import { useEffect } from "react";
 import "~/index.css";
-import { useNavigate } from "react-router-dom";
+// import { useNavigate } from "react-router-dom";
 
 const GoogleLoginComponent = () => {
   const dispatch = useDispatch(); // Redux 디스패치 훅
-  const navigate = useNavigate(); // React Router 훅 (리디렉션 용)
+  // const navigate = useNavigate(); // React Router 훅 (리디렉션 용)
 
   useEffect(() => {
     const exchangeToken = async () => {
@@ -27,7 +27,7 @@ const GoogleLoginComponent = () => {
           if (accessToken) {
             localStorage.setItem("access-token", accessToken);
             dispatch(loginSuccess({ accessToken }));
-            navigate("/main"); // 메인 페이지로 이동
+            // navigate("/main"); // 메인 페이지로 이동
           }
         } else {
           console.error("Token exchange failed");
@@ -43,11 +43,11 @@ const GoogleLoginComponent = () => {
 
     if (error) {
       alert("이메일이 중복되었습니다. 다른 계정으로 회원가입해주세요.");
-      navigate("/signup");
+      // navigate("/signup");
     } else {
       exchangeToken(); // 로그인 성공 시 토큰 교환
     }
-  }, [navigate, dispatch]);
+  }, [dispatch]);
 
   // OAuth 회원가입 버튼 클릭 시 해당 소셜 로그인 URL로 이동
   const onGoogleLogin = () => {

--- a/frontend/src/components/social-login/kakao-login.jsx
+++ b/frontend/src/components/social-login/kakao-login.jsx
@@ -50,9 +50,8 @@ const KakaoLogin = () => {
   }, [navigate, dispatch]);
 
   // OAuth 회원가입 버튼 클릭 시 해당 소셜 로그인 URL로 이동
-  const onKakaoLogin = (provider) => {
-    const redirectUri = "http://localhost:5173/main"; // 로그인 후 리디렉션할 URI
-    window.location.href = `http://localhost:8080/oauth2/authorization/${provider}?redirect_uri=${encodeURIComponent(redirectUri)}`;
+  const onKakaoLogin = () => {
+    window.location.href = "http://localhost:8080/oauth2/authorization/kakao";
   };
 
   return (

--- a/frontend/src/components/social-login/kakao-login.jsx
+++ b/frontend/src/components/social-login/kakao-login.jsx
@@ -2,11 +2,11 @@ import { useEffect } from "react";
 import { useDispatch } from "react-redux";
 import { loginSuccess } from "~/redux/auth-slice";
 import "~/index.css";
-import { useNavigate } from "react-router-dom";
+// import { useNavigate } from "react-router-dom";
 
 const KakaoLogin = () => {
   const dispatch = useDispatch(); // Redux 디스패치 훅
-  const navigate = useNavigate(); // React Router 훅
+  // const navigate = useNavigate(); // React Router 훅
 
   useEffect(() => {
     const exchangeToken = async () => {
@@ -27,7 +27,7 @@ const KakaoLogin = () => {
           if (accessToken) {
             localStorage.setItem("access-token", accessToken);
             dispatch(loginSuccess({ accessToken }));
-            navigate("/main"); // 메인 페이지로 이동
+            // navigate("/main"); // 메인 페이지로 이동
           }
         } else {
           console.error("Token exchange failed");
@@ -43,11 +43,11 @@ const KakaoLogin = () => {
 
     if (error) {
       alert("이메일이 중복되었습니다. 다른 계정으로 회원가입해주세요.");
-      navigate("/signup");
+      // navigate("/signup");
     } else {
       exchangeToken(); // 회원가입 성공 시 토큰 교환
     }
-  }, [navigate, dispatch]);
+  }, [dispatch]);
 
   // OAuth 회원가입 버튼 클릭 시 해당 소셜 로그인 URL로 이동
   const onKakaoLogin = () => {

--- a/frontend/src/components/social-login/kakao-login.jsx
+++ b/frontend/src/components/social-login/kakao-login.jsx
@@ -1,30 +1,83 @@
 import { useEffect } from "react";
 import { useDispatch } from "react-redux";
 import { loginSuccess } from "~/redux/auth-slice";
+import { useNavigate } from "react-router-dom";
 
 const KakaoLogin = () => {
-  const dispatch = useDispatch();
+  const dispatch = useDispatch(); // Redux 디스패치 훅
+  const navigate = useNavigate(); // React Router 훅
 
   useEffect(() => {
-    const script = document.createElement("script");
-    script.src = "https://developers.kakao.com/sdk/js/kakao.js";
-    script.async = true;
-    script.onload = () => window.Kakao.init(import.meta.env.VITE_KAKAO_APP_KEY);
-    document.head.appendChild(script);
-  }, []);
+     // 카카오 SDK 로드
+     const script = document.createElement("script");
+     script.src = "https://developers.kakao.com/sdk/js/kakao.js";
+     script.async = true;
+     script.onload = () => {
+       if (window.Kakao) {
+         // import.meta.env에서 카카오 앱 키를 가져옴
+         window.Kakao.init(import.meta.env.VITE_KAKAO_APP_KEY); // 카카오 앱 키로 초기화
+       }
+     };
+     document.head.appendChild(script); // 스크립트 문서에 추가
+   }, []);
 
-  const handleKakaoLogin = () => {
+   const handleKakaoLogin = () => {
     window.Kakao.Auth.login({
       success: async (authObj) => {
-        const res = await fetch(`${import.meta.env.VITE_BACKEND_API_URL}/auth/kakao`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ token: authObj.access_token }),
-        });
-        const data = await res.json();
-        dispatch(loginSuccess({ user: data.user, token: data.token }));
+        try {
+          // 카카오 로그인 후 받은 토큰을 백엔드로 전송
+          const res = await fetch("http://localhost:8080/api/v1/auth/kakao", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ token: authObj.access_token }),
+          });
+
+          if (!res.ok) throw new Error("Failed to fetch");
+          const data = await res.json(); // 백엔드에서 받은 데이터
+
+          // Redux 스토어에 사용자 정보와 토큰을 저장
+          dispatch(loginSuccess({ user: data.user, token: data.token }));
+
+          // 액세스 토큰 교환
+          const exchangeToken = async () => {
+            try {
+              const response = await fetch(
+                "http://localhost:8080/api/v1/auth/token-exchange",
+                {
+                  method: "POST",
+                  headers: {
+                    "Content-Type": "application/json",
+                  },
+                  credentials: "include", // 쿠키를 포함하여 요청
+                }
+              );
+
+              if (response.ok) {
+                const accessToken = response.headers.get("Authorization");
+                if (accessToken) {
+                  localStorage.setItem("access-token", accessToken); // 토큰을 로컬 스토리지에 저장
+                }
+              } else {
+                console.error("Token exchange failed");
+              }
+            } catch (error) {
+              console.error("Error during token exchange:", error);
+            }
+          };
+
+          exchangeToken(); // 토큰 교환 함수 호출
+
+          // 로그인 성공 후 리디렉션 (새로운 사용자면 회원가입 페이지로, 기존 사용자면 메인 페이지로)
+          if (data.isNewUser) {
+            navigate("/signup");
+          } else {
+            navigate("/main");
+          }
+        } catch (error) {
+          console.error("Kakao Login Failed:", error);
+        }
       },
-      fail: (err) => console.error(err),
+      fail: (err) => console.error("Kakao login failed:", err),
     });
   };
 

--- a/frontend/src/components/social-login/kakao-login.jsx
+++ b/frontend/src/components/social-login/kakao-login.jsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { useDispatch } from "react-redux";
 import { loginSuccess } from "~/redux/auth-slice";
+import "~/index.css";
 import { useNavigate } from "react-router-dom";
 
 const KakaoLogin = () => {
@@ -8,81 +9,54 @@ const KakaoLogin = () => {
   const navigate = useNavigate(); // React Router 훅
 
   useEffect(() => {
-     // 카카오 SDK 로드
-     const script = document.createElement("script");
-     script.src = "https://developers.kakao.com/sdk/js/kakao.js";
-     script.async = true;
-     script.onload = () => {
-       if (window.Kakao) {
-         // import.meta.env에서 카카오 앱 키를 가져옴
-         window.Kakao.init(import.meta.env.VITE_KAKAO_APP_KEY); // 카카오 앱 키로 초기화
-       }
-     };
-     document.head.appendChild(script); // 스크립트 문서에 추가
-   }, []);
-
-   const handleKakaoLogin = () => {
-    window.Kakao.Auth.login({
-      success: async (authObj) => {
-        try {
-          // 카카오 로그인 후 받은 토큰을 백엔드로 전송
-          const res = await fetch("http://localhost:8080/api/v1/auth/kakao", {
+    const exchangeToken = async () => {
+      try {
+        const response = await fetch(
+          "http://localhost:8080/api/v1/auth/token-exchange", // 백엔드의 토큰 교환 API
+          {
             method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ token: authObj.access_token }),
-          });
-
-          if (!res.ok) throw new Error("Failed to fetch");
-          const data = await res.json(); // 백엔드에서 받은 데이터
-
-          // Redux 스토어에 사용자 정보와 토큰을 저장
-          dispatch(loginSuccess({ user: data.user, token: data.token }));
-
-          // 액세스 토큰 교환
-          const exchangeToken = async () => {
-            try {
-              const response = await fetch(
-                "http://localhost:8080/api/v1/auth/token-exchange",
-                {
-                  method: "POST",
-                  headers: {
-                    "Content-Type": "application/json",
-                  },
-                  credentials: "include", // 쿠키를 포함하여 요청
-                }
-              );
-
-              if (response.ok) {
-                const accessToken = response.headers.get("Authorization");
-                if (accessToken) {
-                  localStorage.setItem("access-token", accessToken); // 토큰을 로컬 스토리지에 저장
-                }
-              } else {
-                console.error("Token exchange failed");
-              }
-            } catch (error) {
-              console.error("Error during token exchange:", error);
-            }
-          };
-
-          exchangeToken(); // 토큰 교환 함수 호출
-
-          // 로그인 성공 후 리디렉션 (새로운 사용자면 회원가입 페이지로, 기존 사용자면 메인 페이지로)
-          if (data.isNewUser) {
-            navigate("/signup");
-          } else {
-            navigate("/main");
+            headers: {
+              "Content-Type": "application/json",
+            },
+            credentials: "include", // 쿠키 포함
           }
-        } catch (error) {
-          console.error("Kakao Login Failed:", error);
+        );
+
+        if (response.ok) {
+          const accessToken = response.headers.get("Authorization");
+          if (accessToken) {
+            localStorage.setItem("access-token", accessToken);
+            dispatch(loginSuccess({ accessToken }));
+            navigate("/main"); // 메인 페이지로 이동
+          }
+        } else {
+          console.error("Token exchange failed");
         }
-      },
-      fail: (err) => console.error("Kakao login failed:", err),
-    });
+      } catch (error) {
+        console.error("Error during token exchange:", error);
+      }
+    };
+
+    // 에러 발생 시 회원가입 페이지 유지
+    const params = new URLSearchParams(window.location.search);
+    const error = params.get("error");
+
+    if (error) {
+      alert("이메일이 중복되었습니다. 다른 계정으로 회원가입해주세요.");
+      navigate("/signup");
+    } else {
+      exchangeToken(); // 회원가입 성공 시 토큰 교환
+    }
+  }, [navigate, dispatch]);
+
+  // OAuth 회원가입 버튼 클릭 시 해당 소셜 로그인 URL로 이동
+  const onKakaoLogin = (provider) => {
+    const redirectUri = "http://localhost:5173/main"; // 로그인 후 리디렉션할 URI
+    window.location.href = `http://localhost:8080/oauth2/authorization/${provider}?redirect_uri=${encodeURIComponent(redirectUri)}`;
   };
 
   return (
-    <button onClick={handleKakaoLogin} className="btn btn-kakao">
+    <button onClick={onKakaoLogin} className="btn btn-kakao">
       <img
         src="/images/kakao-logo.png"
         alt="카카오 로고"

--- a/frontend/src/components/social-login/naver-login.jsx
+++ b/frontend/src/components/social-login/naver-login.jsx
@@ -6,64 +6,57 @@ import { useNavigate } from "react-router-dom";
 
 const NaverLogin = () => {
   const dispatch = useDispatch();
-  const navigate = useNavigate(); // React Router 훅 (리디렉션 용)
+  const navigate = useNavigate();
 
   useEffect(() => {
-    const script = document.createElement("script");
-    script.src = "https://static.nid.naver.com/js/naveridlogin_js_sdk.v2.js";
-    script.async = true;
-    script.onload = () => {
-      new window.naver.LoginWithNaverId({
-        clientId: import.meta.env.VITE_NAVER_CLIENT_ID,
-        callbackUrl: handleNaverLogin,
-        isPopup: false,
-      }).init();
+    const exchangeToken = async () => {
+      try {
+        const response = await fetch(
+          "http://localhost:8080/api/v1/auth/token-exchange", // 백엔드의 토큰 교환 API
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            credentials: "include", // 쿠키 포함
+          }
+        );
+
+        if (response.ok) {
+          const accessToken = response.headers.get("Authorization");
+          if (accessToken) {
+            localStorage.setItem("access-token", accessToken);
+            dispatch(loginSuccess({ accessToken }));
+            navigate("/main"); // 메인 페이지로 이동
+          }
+        } else {
+          console.error("Token exchange failed");
+        }
+      } catch (error) {
+        console.error("Error during token exchange:", error);
+      }
     };
-    document.head.appendChild(script);
-  }, []);
 
-  // const handleNaverLogin = () => {
-  //   window.location.href = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=YOUR_NAVER_CLIENT_ID&redirect_uri=YOUR_CALLBACK_URL`;
-  // };
+    // 에러 발생 시 회원가입 페이지 유지
+    const params = new URLSearchParams(window.location.search);
+    const error = params.get("error");
 
-  const handleNaverLogin = async () => {
-    try {
-      // 네이버 로그인 후 인증 코드 받아오기
-      const { code } = window.location;
-
-      if (!code) {
-        console.error("No authorization code found.");
-        return;
-      }
-
-      // 인증 코드로 백엔드에서 토큰 요청
-      const res = await fetch("http://localhost:8080/api/v1/auth/naver", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ code }),
-      });
-
-      if (!res.ok) throw new Error("Failed to fetch");
-      const data = await res.json(); // 백엔드에서 받은 데이터
-
-      // Redux 스토어에 사용자 정보와 토큰을 저장
-      dispatch(loginSuccess({ user: data.user, token: data.token }));
-
-      // 신규 사용자면 회원가입 페이지로, 기존 사용자면 메인 페이지로 리디렉션
-      if (data.isNewUser) {
-        navigate("/signup");
-      } else {
-        navigate("/main");
-      }
-
-      console.log("Login Success:", data);
-    } catch (error) {
-      console.error("Naver Login Failed:", error);
+    if (error) {
+      alert("이메일이 중복되었습니다. 다른 계정으로 회원가입해주세요.");
+      navigate("/signup");
+    } else {
+      exchangeToken(); // 로그인 성공 시 토큰 교환
     }
+  }, [navigate, dispatch]);
+
+  // OAuth 회원가입 버튼 클릭 시 해당 소셜 로그인 URL로 이동
+  const onNaverLogin = (provider) => {
+    const redirectUri = "http://localhost:5173/main"; // 로그인 후 리디렉션할 URI
+    window.location.href = `http://localhost:8080/oauth2/authorization/${provider}?redirect_uri=${encodeURIComponent(redirectUri)}`;
   };
   
   return (
-    <button onClick={handleNaverLogin} className="btn btn-naver">
+    <button onClick={onNaverLogin} className="btn btn-naver">
       <img
         src="/images/naver-logo.png"
         alt="네이버 로고"

--- a/frontend/src/components/social-login/naver-login.jsx
+++ b/frontend/src/components/social-login/naver-login.jsx
@@ -2,11 +2,11 @@ import { useEffect } from "react";
 import { useDispatch } from "react-redux";
 import { loginSuccess } from "~/redux/auth-slice";
 import "~/index.css";
-import { useNavigate } from "react-router-dom";
+// import { useNavigate } from "react-router-dom";
 
 const NaverLogin = () => {
   const dispatch = useDispatch();
-  const navigate = useNavigate();
+  // const navigate = useNavigate();
 
   useEffect(() => {
     const exchangeToken = async () => {
@@ -27,7 +27,7 @@ const NaverLogin = () => {
           if (accessToken) {
             localStorage.setItem("access-token", accessToken);
             dispatch(loginSuccess({ accessToken }));
-            navigate("/main"); // 메인 페이지로 이동
+            // navigate("/main"); // 메인 페이지로 이동
           }
         } else {
           console.error("Token exchange failed");
@@ -43,11 +43,11 @@ const NaverLogin = () => {
 
     if (error) {
       alert("이메일이 중복되었습니다. 다른 계정으로 회원가입해주세요.");
-      navigate("/signup");
+      // navigate("/signup");
     } else {
       exchangeToken(); // 로그인 성공 시 토큰 교환
     }
-  }, [navigate, dispatch]);
+  }, [dispatch]);
 
   // OAuth 회원가입 버튼 클릭 시 해당 소셜 로그인 URL로 이동
   const onNaverLogin = () => {

--- a/frontend/src/components/social-login/naver-login.jsx
+++ b/frontend/src/components/social-login/naver-login.jsx
@@ -1,8 +1,12 @@
 import { useEffect } from "react";
 import { useDispatch } from "react-redux";
+import { loginSuccess } from "~/redux/auth-slice";
+import "~/index.css";
+import { useNavigate } from "react-router-dom";
 
 const NaverLogin = () => {
   const dispatch = useDispatch();
+  const navigate = useNavigate(); // React Router 훅 (리디렉션 용)
 
   useEffect(() => {
     const script = document.createElement("script");
@@ -11,15 +15,51 @@ const NaverLogin = () => {
     script.onload = () => {
       new window.naver.LoginWithNaverId({
         clientId: import.meta.env.VITE_NAVER_CLIENT_ID,
-        callbackUrl: import.meta.env.VITE_NAVER_CALLBACK_URL,
+        callbackUrl: handleNaverLogin,
         isPopup: false,
       }).init();
     };
     document.head.appendChild(script);
   }, []);
 
-  const handleNaverLogin = () => {
-    window.location.href = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${import.meta.env.VITE_NAVER_CLIENT_ID}&redirect_uri=${import.meta.env.VITE_NAVER_CALLBACK_URL}`;
+  // const handleNaverLogin = () => {
+  //   window.location.href = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=YOUR_NAVER_CLIENT_ID&redirect_uri=YOUR_CALLBACK_URL`;
+  // };
+
+  const handleNaverLogin = async () => {
+    try {
+      // 네이버 로그인 후 인증 코드 받아오기
+      const { code } = window.location;
+
+      if (!code) {
+        console.error("No authorization code found.");
+        return;
+      }
+
+      // 인증 코드로 백엔드에서 토큰 요청
+      const res = await fetch("http://localhost:8080/api/v1/auth/naver", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ code }),
+      });
+
+      if (!res.ok) throw new Error("Failed to fetch");
+      const data = await res.json(); // 백엔드에서 받은 데이터
+
+      // Redux 스토어에 사용자 정보와 토큰을 저장
+      dispatch(loginSuccess({ user: data.user, token: data.token }));
+
+      // 신규 사용자면 회원가입 페이지로, 기존 사용자면 메인 페이지로 리디렉션
+      if (data.isNewUser) {
+        navigate("/signup");
+      } else {
+        navigate("/main");
+      }
+
+      console.log("Login Success:", data);
+    } catch (error) {
+      console.error("Naver Login Failed:", error);
+    }
   };
   
   return (

--- a/frontend/src/components/social-login/naver-login.jsx
+++ b/frontend/src/components/social-login/naver-login.jsx
@@ -50,9 +50,8 @@ const NaverLogin = () => {
   }, [navigate, dispatch]);
 
   // OAuth 회원가입 버튼 클릭 시 해당 소셜 로그인 URL로 이동
-  const onNaverLogin = (provider) => {
-    const redirectUri = "http://localhost:5173/main"; // 로그인 후 리디렉션할 URI
-    window.location.href = `http://localhost:8080/oauth2/authorization/${provider}?redirect_uri=${encodeURIComponent(redirectUri)}`;
+  const onNaverLogin = () => {
+    window.location.href = "http://localhost:8080/oauth2/authorization/naver";
   };
   
   return (

--- a/frontend/src/components/social-signup/google-signup.jsx
+++ b/frontend/src/components/social-signup/google-signup.jsx
@@ -57,14 +57,15 @@ const GoogleSignup = () => {
 
   return (
     <button onClick={onGoogleSignup} className="btn btn-google flex items-center 
-      justify-start gap-10 bg-blue-700 text-black py-2 px-4 rounded-full
-      hover:bg-blue-600 transition-colors duration-200">
+      justify-start gap-8 bg-blue-700 text-black py-2 px-6 rounded-full
+      hover:bg-blue-600 transition-colors duration-200 
+      hover:scale-105 transition-all duration-200 ">
       <img
         src="/images/google-logo.png"
         alt="구글 로고"
         className="w-8 h-8"
       />
-      <span className="ml-20">구글로 회원가입</span>
+      <span className="ml-20">구글로 로그인</span>
     </button>
   );
 };

--- a/frontend/src/components/social-signup/google-signup.jsx
+++ b/frontend/src/components/social-signup/google-signup.jsx
@@ -65,7 +65,7 @@ const GoogleSignup = () => {
         alt="구글 로고"
         className="w-8 h-8"
       />
-      <span className="ml-20">구글로 로그인</span>
+      <span className="ml-20">구글로 회원가입</span>
     </button>
   );
 };

--- a/frontend/src/components/social-signup/google-signup.jsx
+++ b/frontend/src/components/social-signup/google-signup.jsx
@@ -50,9 +50,10 @@ const GoogleSignup = () => {
   }, [navigate, dispatch]);
 
   // OAuth 회원가입 버튼 클릭 시 해당 소셜 로그인 URL로 이동
-  const onGoogleSignup = (provider) => {
-    const redirectUri = "http://localhost:5173/login"; // 회원가입 후 리디렉션할 URI
-    window.location.href = `http://localhost:8080/oauth2/authorization/${provider}?redirect_uri=${encodeURIComponent(redirectUri)}`;
+  const onGoogleSignup = () => {
+    // const redirectUri = "http://localhost:5173/login"; // 회원가입 후 리디렉션할 URI
+    // window.location.href = `http://localhost:8080/oauth2/authorization/${provider}?redirect_uri=${encodeURIComponent(redirectUri)}`;
+    window.location.href = "http://localhost:8080/oauth2/authorization/google";
   };
 
   return (

--- a/frontend/src/components/social-signup/google-signup.jsx
+++ b/frontend/src/components/social-signup/google-signup.jsx
@@ -1,45 +1,72 @@
 import { useEffect } from "react";
 import { useDispatch } from "react-redux";
 import { signupSuccess } from "~/redux/auth-slice";
-import { GoogleLogin } from "@react-oauth/google";
+import "~/index.css";
+import { useNavigate } from "react-router-dom";
 
 const GoogleSignup = () => {
   const dispatch = useDispatch();
-
-  const handleGoogleSignupSuccess = async (response) => {
-    try {
-      const res = await fetch(`${import.meta.env.VITE_BACKEND_API_URL}/signup/google`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ token: response.credential }),
-      });
-
-      if (!res.ok) throw new Error('Failed to signup');
-      const data = await res.json();
-      dispatch(signupSuccess({ user: data.user, token: data.token }));
-      console.log('Signup Success:', data);
-    } catch (error) {
-      console.error('Google Signup Failed:', error);
-    }
-  };
+  const navigate = useNavigate();
 
   useEffect(() => {
-    // 구글 로그인 SDK 로드
-    const script = document.createElement("script");
-    script.src = "https://accounts.google.com/gsi/client";
-    script.async = true;
-    script.onload = () => {
-      window.google.accounts.id.initialize({
-        client_id: import.meta.env.VITE_GOOGLE_CLIENT_ID,
-        callback: handleGoogleSignupSuccess,
-      });
-    };
-    document.head.appendChild(script);
-  }, []);
+    const exchangeToken = async () => {
+      try {
+        const response = await fetch(
+          "http://localhost:8080/api/v1/auth/token-exchange", // 백엔드의 토큰 교환 API
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            credentials: "include", // 쿠키 포함
+          }
+        );
 
-  return <GoogleLogin onSuccess={handleGoogleSignupSuccess} 
-          onError={(error) => console.log('Google Signup Error:', error)} 
-         />;
+        if (response.ok) {
+          const accessToken = response.headers.get("Authorization");
+          if (accessToken) {
+            localStorage.setItem("access-token", accessToken);
+            dispatch(signupSuccess({ accessToken }));
+            navigate("/login"); // 로그인 페이지로 이동
+          }
+        } else {
+          console.error("Token exchange failed");
+        }
+      } catch (error) {
+        console.error("Error during token exchange:", error);
+      }
+    };
+
+    // 에러 발생 시 회원가입 페이지 유지
+    const params = new URLSearchParams(window.location.search);
+    const error = params.get("error");
+
+    if (error) {
+      alert("이메일이 중복되었습니다. 다른 계정으로 회원가입해주세요.");
+      navigate("/signup");
+    } else {
+      exchangeToken(); // 회원가입 성공 시 토큰 교환
+    }
+  }, [navigate, dispatch]);
+
+  // OAuth 회원가입 버튼 클릭 시 해당 소셜 로그인 URL로 이동
+  const onGoogleSignup = (provider) => {
+    const redirectUri = "http://localhost:5173/login"; // 회원가입 후 리디렉션할 URI
+    window.location.href = `http://localhost:8080/oauth2/authorization/${provider}?redirect_uri=${encodeURIComponent(redirectUri)}`;
+  };
+
+  return (
+    <button onClick={onGoogleSignup} className="btn btn-google flex items-center 
+      justify-start gap-10 bg-blue-700 text-black py-2 px-4 rounded-full
+      hover:bg-blue-600 transition-colors duration-200">
+      <img
+        src="/images/google-logo.png"
+        alt="구글 로고"
+        className="w-8 h-8"
+      />
+      <span className="ml-20">구글로 회원가입</span>
+    </button>
+  );
 };
 
 export default GoogleSignup;

--- a/frontend/src/components/social-signup/kakao-signup.jsx
+++ b/frontend/src/components/social-signup/kakao-signup.jsx
@@ -50,9 +50,8 @@ const KakaoSignup = () => {
   }, [navigate, dispatch]);
 
   // OAuth 회원가입 버튼 클릭 시 해당 소셜 로그인 URL로 이동
-  const onKakaoSignup = (provider) => {
-    const redirectUri = "http://localhost:5173/login"; // 회원가입 후 리디렉션할 URI
-    window.location.href = `http://localhost:8080/oauth2/authorization/${provider}?redirect_uri=${encodeURIComponent(redirectUri)}`;
+  const onKakaoSignup = () => {
+    window.location.href = "http://localhost:8080/oauth2/authorization/kakao";
   };
 
   return (

--- a/frontend/src/components/social-signup/kakao-signup.jsx
+++ b/frontend/src/components/social-signup/kakao-signup.jsx
@@ -1,39 +1,63 @@
 import { useEffect } from "react";
 import { useDispatch } from "react-redux";
 import { signupSuccess } from "~/redux/auth-slice";
+import "~/index.css";
+import { useNavigate } from "react-router-dom";
 
 const KakaoSignup = () => {
   const dispatch = useDispatch();
+  const navigate = useNavigate();
 
   useEffect(() => {
-    const script = document.createElement("script");
-    script.src = "https://developers.kakao.com/sdk/js/kakao.js";
-    script.async = true;
-    script.onload = () => {
-      window.Kakao.init(import.meta.env.VITE_KAKAO_APP_KEY);
-    };
-    document.head.appendChild(script);
-  }, []);
+    const exchangeToken = async () => {
+      try {
+        const response = await fetch(
+          "http://localhost:8080/api/v1/auth/token-exchange", // 백엔드의 토큰 교환 API
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            credentials: "include", // 쿠키 포함
+          }
+        );
 
-  const handleKakaoSignup = () => {
-    window.Kakao.Auth.login({
-      success: async (authObj) => {
-        const res = await fetch(`${import.meta.env.VITE_BACKEND_API_URL}/signup/kakao`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ token: authObj.access_token }),
-        });
-        const data = await res.json();
-        dispatch(signupSuccess({ user: data.user, token: data.token }));
-        console.log("Kakao Signup Success:", data);
-      },
-      fail: (err) => console.error(err),
-    });
+        if (response.ok) {
+          const accessToken = response.headers.get("Authorization");
+          if (accessToken) {
+            localStorage.setItem("access-token", accessToken);
+            dispatch(signupSuccess({ accessToken }));
+            navigate("/login"); // 로그인 페이지로 이동
+          }
+        } else {
+          console.error("Token exchange failed");
+        }
+      } catch (error) {
+        console.error("Error during token exchange:", error);
+      }
+    };
+
+    // 에러 발생 시 회원가입 페이지 유지
+    const params = new URLSearchParams(window.location.search);
+    const error = params.get("error");
+
+    if (error) {
+      alert("이메일이 중복되었습니다. 다른 계정으로 회원가입해주세요.");
+      navigate("/signup");
+    } else {
+      exchangeToken(); // 회원가입 성공 시 토큰 교환
+    }
+  }, [navigate, dispatch]);
+
+  // OAuth 회원가입 버튼 클릭 시 해당 소셜 로그인 URL로 이동
+  const onKakaoSignup = (provider) => {
+    const redirectUri = "http://localhost:5173/login"; // 회원가입 후 리디렉션할 URI
+    window.location.href = `http://localhost:8080/oauth2/authorization/${provider}?redirect_uri=${encodeURIComponent(redirectUri)}`;
   };
 
   return (
     <div className="flex justify-center items-center">
-      <button onClick={handleKakaoSignup} className="btn btn-kakao">
+      <button onClick={onKakaoSignup} className="btn btn-kakao">
         <img src="/images/kakao-logo.png" alt="카카오 로고" className="w-10 h-10" />
         <span>카카오로 회원가입</span>
       </button>

--- a/frontend/src/components/social-signup/naver-signup.jsx
+++ b/frontend/src/components/social-signup/naver-signup.jsx
@@ -1,31 +1,63 @@
 import { useEffect } from "react";
 import { useDispatch } from "react-redux";
 import { signupSuccess } from "~/redux/auth-slice";
+import "~/index.css";
+import { useNavigate } from "react-router-dom";
 
 const NaverSignup = () => {
   const dispatch = useDispatch();
+  const navigate = useNavigate();
 
   useEffect(() => {
-    const script = document.createElement("script");
-    script.src = "https://static.nid.naver.com/js/naveridlogin_js_sdk.v2.js";
-    script.async = true;
-    script.onload = () => {
-      new window.naver.LoginWithNaverId({
-        clientId: "YOUR_NAVER_CLIENT_ID",
-        callbackUrl: "YOUR_CALLBACK_URL",
-        isPopup: false,
-      }).init();
-    };
-    document.head.appendChild(script);
-  }, []);
+    const exchangeToken = async () => {
+      try {
+        const response = await fetch(
+          "http://localhost:8080/api/v1/auth/token-exchange", // 백엔드의 토큰 교환 API
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            credentials: "include", // 쿠키 포함
+          }
+        );
 
-  const handleNaverSignup = () => {
-    window.location.href = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=YOUR_NAVER_CLIENT_ID&redirect_uri=YOUR_CALLBACK_URL`;
+        if (response.ok) {
+          const accessToken = response.headers.get("Authorization");
+          if (accessToken) {
+            localStorage.setItem("access-token", accessToken);
+            dispatch(signupSuccess({ accessToken }));
+            navigate("/main"); // 메인 페이지로 이동
+          }
+        } else {
+          console.error("Token exchange failed");
+        }
+      } catch (error) {
+        console.error("Error during token exchange:", error);
+      }
+    };
+
+    // 에러 발생 시 회원가입 페이지 유지
+    const params = new URLSearchParams(window.location.search);
+    const error = params.get("error");
+
+    if (error) {
+      alert("이메일이 중복되었습니다. 다른 계정으로 회원가입해주세요.");
+      navigate("/signup");
+    } else {
+      exchangeToken(); // 회원가입 성공 시 토큰 교환
+    }
+  }, [navigate, dispatch]);
+
+  // OAuth 회원가입 버튼 클릭 시 해당 소셜 로그인 URL로 이동
+  const onNaverSignup = (provider) => {
+    const redirectUri = "http://localhost:5173/login"; // 회원가입 후 리디렉션할 URI
+    window.location.href = `http://localhost:8080/oauth2/authorization/${provider}?redirect_uri=${encodeURIComponent(redirectUri)}`;
   };
 
   return (
     <div className="flex justify-center items-center">
-      <button onClick={handleNaverSignup} className="btn btn-naver">
+      <button onClick={onNaverSignup} className="btn btn-naver">
         <img src="/images/naver-logo.png" alt="네이버 로고" className="w-10 h-10" />
         <span>네이버로 회원가입</span>
       </button>

--- a/frontend/src/components/social-signup/naver-signup.jsx
+++ b/frontend/src/components/social-signup/naver-signup.jsx
@@ -50,9 +50,8 @@ const NaverSignup = () => {
   }, [navigate, dispatch]);
 
   // OAuth 회원가입 버튼 클릭 시 해당 소셜 로그인 URL로 이동
-  const onNaverSignup = (provider) => {
-    const redirectUri = "http://localhost:5173/login"; // 회원가입 후 리디렉션할 URI
-    window.location.href = `http://localhost:8080/oauth2/authorization/${provider}?redirect_uri=${encodeURIComponent(redirectUri)}`;
+  const onNaverSignup = () => {
+    window.location.href = "http://localhost:8080/oauth2/authorization/naver";
   };
 
   return (

--- a/frontend/src/components/social-signup/social-signup-buttons.jsx
+++ b/frontend/src/components/social-signup/social-signup-buttons.jsx
@@ -1,0 +1,15 @@
+import KakaoSignup from "~/components/social-signup/kakao-signup.jsx";
+import NaverSignup from "~/components/social-signup/naver-signup.jsx";
+import GoogleSignup from "~/components/social-signup/google-signup.jsx";
+
+const SocialLoginButtons = () => {
+  return (
+    <div className="flex flex-col gap-4">
+      <KakaoSignup />
+      <NaverSignup />
+      <GoogleSignup />
+    </div>
+  );
+};
+
+export default SocialLoginButtons;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -9,12 +9,14 @@
   }
 
   .btn-kakao {
-    @apply bg-yellow-400 text-black hover:bg-yellow-300;
+    @apply bg-yellow-400 text-black hover:bg-yellow-300
+    hover:scale-105 transition-all duration-200;
   }
 
   .btn-naver {
     @apply bg-gradient-to-r from-green-500 to-green-600 
-    text-white hover:from-green-600 hover:to-green-700;
+    text-white hover:from-green-600 hover:to-green-700
+    hover:scale-105 transition-all duration-200;
   }
 
   /* 이미지 왼쪽 정렬 */

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5,7 +5,7 @@
 @layer components {
   .btn {
     @apply w-full h-16 flex items-center relative py-3 px-5 
-    rounded-3xl shadow-md transition-all duration-300 text-lg font-semibold;
+    rounded-full shadow-md transition-all duration-300 text-lg font-semibold;
   }
 
   .btn-kakao {

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -3,8 +3,11 @@ import ReactDOM from "react-dom/client";
 import App from "~/App";
 import { Provider } from "react-redux";
 import store from "~/redux/store";
+<<<<<<< HEAD
 import "./index.css"; // ✅ Tailwind 스타일 불러오기
 
+=======
+>>>>>>> 094f654 (로그인 구글 버튼 UI 통일 & src/ @->~로 변경)
 
 const rootElement = document.getElementById("root");
 const root = ReactDOM.createRoot(rootElement);

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -3,11 +3,6 @@ import ReactDOM from "react-dom/client";
 import App from "~/App";
 import { Provider } from "react-redux";
 import store from "~/redux/store";
-<<<<<<< HEAD
-import "./index.css"; // ✅ Tailwind 스타일 불러오기
-
-=======
->>>>>>> 094f654 (로그인 구글 버튼 UI 통일 & src/ @->~로 변경)
 
 const rootElement = document.getElementById("root");
 const root = ReactDOM.createRoot(rootElement);

--- a/frontend/src/pages/login-page.jsx
+++ b/frontend/src/pages/login-page.jsx
@@ -1,26 +1,21 @@
-<<<<<<< HEAD
 import SocialLoginButtons from '~/components/social-login/social-login-buttons';
 import LogoutButton from '~/components/logout-button';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch  } from 'react-redux';
 import { useEffect } from 'react';
 import Main from '~/main-page.jsx';
 import { useNavigate } from 'react-router-dom';
-=======
-import SocialLoginButtons from "~/components/social-login/social-login-buttons";
-import LogoutButton from "~/components/logout-button";
-import { useSelector, useDispatch } from "react-redux";
-import { useEffect } from "react";
-import Main from "~/main-page.jsx"
-import { useNavigate } from "react-router-dom";
->>>>>>> 094f654 (로그인 구글 버튼 UI 통일 & src/ @->~로 변경)
+import { loginSuccess } from "~/redux/auth-slice";
 
 function LoginPage() {
+  // Redux에서 로그인 상태 가져오기
   const isAuthenticated = useSelector((state) => state.auth.isAuthenticated);
+  const dispatch = useDispatch(); // 액션 디스패치 함수
   const navigate = useNavigate();
 
+  // 로그인 상태가 true이면 메인 페이지로 이동
   useEffect(() => {
     if (isAuthenticated) {
-      navigate('/');
+      navigate('/main'); // 로그인 성공 시 메인 페이지로
     }
   }, [isAuthenticated, navigate]);
 
@@ -28,9 +23,9 @@ function LoginPage() {
     <div className="flex justify-center items-center min-h-screen bg-gray-200">
       <div className="w-full h-128 max-w-lg bg-white p-8 rounded-2xl shadow-lg">
         <h1 className="text-3xl font-bold text-center mb-16 mt-4">
-          {isAuthenticated ? <Main /> : '8＋1 B❗t LOGIN'}
+          {loginSuccess ? <Main /> : '8＋1 B❗t LOGIN'}
         </h1>
-        {isAuthenticated ? <LogoutButton /> : <SocialLoginButtons />}
+        {loginSuccess ? <LogoutButton /> : <SocialLoginButtons />}
       </div>
     </div>
   );

--- a/frontend/src/pages/login-page.jsx
+++ b/frontend/src/pages/login-page.jsx
@@ -1,9 +1,18 @@
+<<<<<<< HEAD
 import SocialLoginButtons from '~/components/social-login/social-login-buttons';
 import LogoutButton from '~/components/logout-button';
 import { useSelector } from 'react-redux';
 import { useEffect } from 'react';
 import Main from '~/main-page.jsx';
 import { useNavigate } from 'react-router-dom';
+=======
+import SocialLoginButtons from "~/components/social-login/social-login-buttons";
+import LogoutButton from "~/components/logout-button";
+import { useSelector, useDispatch } from "react-redux";
+import { useEffect } from "react";
+import Main from "~/main-page.jsx"
+import { useNavigate } from "react-router-dom";
+>>>>>>> 094f654 (로그인 구글 버튼 UI 통일 & src/ @->~로 변경)
 
 function LoginPage() {
   const isAuthenticated = useSelector((state) => state.auth.isAuthenticated);

--- a/frontend/src/pages/login-page.jsx
+++ b/frontend/src/pages/login-page.jsx
@@ -1,33 +1,25 @@
 import SocialLoginButtons from '~/components/social-login/social-login-buttons';
-import LogoutButton from '~/components/logout-button';
-import { useSelector, useDispatch  } from 'react-redux';
-import { useEffect } from 'react';
-import Main from '~/main-page.jsx';
-import { useNavigate } from 'react-router-dom';
-import { loginSuccess } from "~/redux/auth-slice";
+// import LogoutButton from '~/components/logout-button';
+// import { useSelector, useDispatch  } from 'react-redux';
+// import { useEffect } from 'react';
+// import Main from '~/main-page.jsx';
+// import { useNavigate } from 'react-router-dom';
+// import { loginSuccess } from "~/redux/auth-slice";
 
 function LoginPage() {
-  // Redux에서 로그인 상태 가져오기
-  const isAuthenticated = useSelector((state) => state.auth.isAuthenticated);
-  const dispatch = useDispatch(); // 액션 디스패치 함수
-  const navigate = useNavigate();
+  // // Redux에서 로그인 상태 가져오기
+  // const isAuthenticated = useSelector((state) => state.auth.isAuthenticated);
+  // const dispatch = useDispatch(); // 액션 디스패치 함수
+  // const navigate = useNavigate();
 
-  // 로그인 상태가 true이면 메인 페이지로 이동
-  useEffect(() => {
-    if (isAuthenticated) {
-      navigate('/main'); // 로그인 성공 시 메인 페이지로
-    }
-  }, [isAuthenticated, navigate]);
+  // // 로그인 상태가 true이면 메인 페이지로 이동
+  // useEffect(() => {
+  //   if (isAuthenticated) {
+  //     navigate('/main'); // 로그인 성공 시 메인 페이지로
+  //   }
+  // }, [isAuthenticated, navigate]);
 
   return (
-    // <div className="flex justify-center items-center min-h-screen bg-gray-200">
-    //   <div className="w-full h-128 max-w-lg bg-white p-8 rounded-2xl shadow-lg">
-    //     <h1 className="text-3xl font-bold text-center mb-16 mt-4">
-    //       {isAuthenticated ? <Main /> : '8＋1 B❗t LOGIN'}
-    //     </h1>
-    //     {isAuthenticated ? <LogoutButton /> : <SocialLoginButtons />}
-    //   </div>
-    // </div>
     <div className="flex justify-center items-center min-h-screen relative">
       {/* Logo Placeholder */}
       <div className="w-40 bg-gray-400 text-center py-4 absolute top-0 left-0 z-10">
@@ -41,44 +33,6 @@ function LoginPage() {
 
       {/* Right Section (Email and Password Fields) */}
       <div className="w-1/2 pl-6 pr-6">
-        {/* Email Input */}
-        <div className="mb-6">
-          <label htmlFor="email" className="block text-lg font-medium text-gray-700">Email</label>
-          <div className="relative">
-            <input
-              id="email"
-              type="email"
-              placeholder="이메일을 @형식으로 입력하세요"
-              className="w-full h-12 pl-4 pr-12 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-            />
-          </div>
-        </div>
-
-        {/* Password Input */}
-        <div className="mb-6">
-          <label htmlFor="password" className="block text-lg font-medium text-gray-700">Password</label>
-          <div className="relative">
-            <input
-              id="password"
-              type="password"
-              placeholder="비밀번호를 입력하세요"
-              className="w-full h-12 pl-4 pr-12 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-            />
-            <span className="absolute right-4 top-1/2 transform -translate-y-1/2 cursor-pointer">
-              👁️
-            </span>
-          </div>
-        </div>
-
-        {/* Forgot Password */}
-        <div className="text-sm text-gray-600 mb-6">
-          <a href="#" className="hover:underline">비밀번호를 잊으셨나요?</a>
-        </div>
-
-        {/* Login Button */}
-        <button className="w-full h-12 bg-blue-500 text-white text-lg font-semibold rounded-md hover:bg-blue-600">
-          로그인하기
-        </button>
 
         {/* Social Login Buttons */}
         <div className="mt-20 flex flex-col gap-4">

--- a/frontend/src/pages/login-page.jsx
+++ b/frontend/src/pages/login-page.jsx
@@ -20,12 +20,70 @@ function LoginPage() {
   }, [isAuthenticated, navigate]);
 
   return (
-    <div className="flex justify-center items-center min-h-screen bg-gray-200">
-      <div className="w-full h-128 max-w-lg bg-white p-8 rounded-2xl shadow-lg">
-        <h1 className="text-3xl font-bold text-center mb-16 mt-4">
-          {isAuthenticated ? <Main /> : '8＋1 B❗t LOGIN'}
-        </h1>
-        {isAuthenticated ? <LogoutButton /> : <SocialLoginButtons />}
+    // <div className="flex justify-center items-center min-h-screen bg-gray-200">
+    //   <div className="w-full h-128 max-w-lg bg-white p-8 rounded-2xl shadow-lg">
+    //     <h1 className="text-3xl font-bold text-center mb-16 mt-4">
+    //       {isAuthenticated ? <Main /> : '8＋1 B❗t LOGIN'}
+    //     </h1>
+    //     {isAuthenticated ? <LogoutButton /> : <SocialLoginButtons />}
+    //   </div>
+    // </div>
+    <div className="flex justify-center items-center min-h-screen relative">
+      {/* Logo Placeholder */}
+      <div className="w-40 bg-gray-400 text-center py-4 absolute top-0 left-0 z-10">
+        <span className="text-black">로고 들어갈 자리</span>
+      </div>
+
+      {/* Image Placeholder */}
+      <div className="w-1/2 min-h-screen bg-gray-200 flex justify-center items-center">
+        <span className="text-black">이미지 들어갈 자리</span>
+      </div>
+
+      {/* Right Section (Email and Password Fields) */}
+      <div className="w-1/2 pl-6 pr-6">
+        {/* Email Input */}
+        <div className="mb-6">
+          <label htmlFor="email" className="block text-lg font-medium text-gray-700">Email</label>
+          <div className="relative">
+            <input
+              id="email"
+              type="email"
+              placeholder="이메일을 @형식으로 입력하세요"
+              className="w-full h-12 pl-4 pr-12 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+        </div>
+
+        {/* Password Input */}
+        <div className="mb-6">
+          <label htmlFor="password" className="block text-lg font-medium text-gray-700">Password</label>
+          <div className="relative">
+            <input
+              id="password"
+              type="password"
+              placeholder="비밀번호를 입력하세요"
+              className="w-full h-12 pl-4 pr-12 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            <span className="absolute right-4 top-1/2 transform -translate-y-1/2 cursor-pointer">
+              👁️
+            </span>
+          </div>
+        </div>
+
+        {/* Forgot Password */}
+        <div className="text-sm text-gray-600 mb-6">
+          <a href="#" className="hover:underline">비밀번호를 잊으셨나요?</a>
+        </div>
+
+        {/* Login Button */}
+        <button className="w-full h-12 bg-blue-500 text-white text-lg font-semibold rounded-md hover:bg-blue-600">
+          로그인하기
+        </button>
+
+        {/* Social Login Buttons */}
+        <div className="mt-20 flex flex-col gap-4">
+          <SocialLoginButtons />
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/pages/login-page.jsx
+++ b/frontend/src/pages/login-page.jsx
@@ -23,9 +23,9 @@ function LoginPage() {
     <div className="flex justify-center items-center min-h-screen bg-gray-200">
       <div className="w-full h-128 max-w-lg bg-white p-8 rounded-2xl shadow-lg">
         <h1 className="text-3xl font-bold text-center mb-16 mt-4">
-          {loginSuccess ? <Main /> : '8＋1 B❗t LOGIN'}
+          {isAuthenticated ? <Main /> : '8＋1 B❗t LOGIN'}
         </h1>
-        {loginSuccess ? <LogoutButton /> : <SocialLoginButtons />}
+        {isAuthenticated ? <LogoutButton /> : <SocialLoginButtons />}
       </div>
     </div>
   );

--- a/frontend/src/pages/signup-page.jsx
+++ b/frontend/src/pages/signup-page.jsx
@@ -1,17 +1,30 @@
-import GoogleSignup from "~/components/social-signup/google-signup.jsx";
-import KakaoSignup from "~/components/social-signup/kakao-signup.jsx";
-import NaverSignup from "~/components/social-signup/naver-signup.jsx";
+import SocialLoginButtons from "~/components/social-signup/social-signup-buttons.jsx";
+import { useSelector, useDispatch } from "react-redux";
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { signupSuccess } from "~/redux/auth-slice";
 
 const SignupPage = () => {
+  // Redux에서 로그인 상태 가져오기
+  const isAuthenticated = useSelector((state) => state.auth.isAuthenticated);
+  const signupStatus = useSelector((state) => state.auth.signupSuccess); // 회원가입 상태
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+
+  // 회원가입 성공 시 로그인 페이지로 리디렉션
+  useEffect(() => {
+    if (signupStatus) {
+      navigate("/login");
+    }
+  }, [signupStatus, navigate]);
+
   return (
     <div className="flex justify-center items-center min-h-screen bg-gray-200">
-      <div className="w-full max-w-lg bg-white p-8 rounded-2xl shadow-lg">
-        <h1 className="text-3xl font-bold text-center mb-8">회원가입</h1>
-        <div className="space-y-4">
-          <GoogleSignup />
-          <KakaoSignup />
-          <NaverSignup />
-        </div>
+      <div className="w-full h-128 max-w-lg bg-white p-8 rounded-2xl shadow-lg">
+        <h1 className="text-3xl font-bold text-center mb-16 mt-4">
+          {signupStatus ? "회원가입 성공" : "8＋1 B❗t SIGNUP"}
+        </h1>
+        <SocialLoginButtons />
       </div>
     </div>
   );


### PR DESCRIPTION
- 제목 : feat&design(issue #13)

## 🔎 작업 내용

- 이메일 비밀번호 뺀다고 하셔서 그부분 지우고 소셜만 남겨놓음
- 불필요한 코드 ( /main, /signup 이런 네이게이션 부분 ) 주석 처리함 -> 백엔드에서 다 처리해놨다고 함

-  회원가입은 안 만든다고 하셔서 이슈랑 브랜치 삭제함

  <br/>

## 이미지 첨부

![image](https://github.com/user-attachments/assets/d044cc13-b3f3-4927-854c-b7e1ee060e1f)
![image](https://github.com/user-attachments/assets/938673f3-68d1-4a45-8ddf-a74d255e61bd)

<br/>

## 🔧 앞으로의 과제

- 홈페이지 틀 만들기
- 로그아웃 기능 만들기

  <br/>

## ➕ 이슈 링크

- [레포 이름 #13](https://github.com/FiT-8-plus-1-BiT/frontend/issues/13)

<br/>